### PR TITLE
Pin amaranth-yosys and python

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -5,6 +5,7 @@ channels:
     - litex-hub
     - conda-forge
 dependencies:
+    - conda-forge::python=3.10.9=he550d4f_0_cpython
     - litex-hub::gcc-lm32-elf-newlib=9.2.0=20210513_184432
     - litex-hub::gcc-or1k-elf-newlib=9.2.0=20210513_184432
     - antmicro::gcc-ppc64le-linux-musl=12.1.0=20221019_1514

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ gitpython
 meson==0.59
 ninja
 amaranth
-amaranth-yosys
+amaranth-yosys==0.25.0.0.post69


### PR DESCRIPTION
This PR fixes failing benchmark runs for minerva cpu by:
* pinning amaranth-yosys to `0.25.0.0.post69`
* pinning python to `3.10.9`